### PR TITLE
added WORKDIR for improved local file handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -155,6 +155,9 @@ ENV \
 CMD python -m eccodes selfcheck
 COPY ./samples /samples
 
+# Create a workdir that will be used as a mount point for local filesystem
+WORKDIR /local
+
 # METADATA
 # Build-time metadata as defined at http://label-schema.org
 # --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ edition      centre       date         dataType     gridType     stepRange    ty
 ## Example 2: Extract meta data from grib file on local hard drive
 If you have a local grib file ``some-file.grib2`` and you want to run ``grib_ls`` on this file:
 ```
-docker run --rm --mount type=bind,source="$(pwd)"/some-file.grib2,target=/my.grib2 deutscherwetterdienst/python-eccodes grib_ls /my.grib2
+docker run --rm --mount type=bind,source="$(pwd)"/,target=/local deutscherwetterdienst/python-eccodes grib_ls some-file.grib2
 ```
 Example output of ``grib_ls``:
 ```


### PR DESCRIPTION
This change makes the "/my.grib2" obsolete. It also allows to process multiple files like
```docker run --rm --mount type=bind,source="$(pwd)"/,target=/local deutscherwetterdienst/python-eccodes grib_ls some-file.grib2 another_file.grib2```
Also wildcards work:
```docker run --rm --mount type=bind,source="$(pwd)"/,target=/local deutscherwetterdienst/python-eccodes grib_ls my_grib*.grib2```